### PR TITLE
Upgrade `?` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=g++
-SOURCES=./src/qqq.cpp
+SOURCES=./cpp/qqq.cpp
 EXECUTABLE=./bin/qqq
 
 all:

--- a/cpp/qqq.cpp
+++ b/cpp/qqq.cpp
@@ -45,6 +45,7 @@ int from_line(environment &env, std::string &line, int open_quotes = 0);
 int from_stream(environment &env, std::istream &stream, int open_quotes = 0);
 void interactive_mode(environment &env);
 void print_cell(CELL cell);
+char get_cell();
 
 
 int main(int argc, const char* argv[]) {
@@ -95,6 +96,19 @@ void print_cell(CELL cell) {
         std::cout << "0x" << std::hex << (int)cell << std::dec;
 }
 
+/*
+ * Reads a character from STDIN
+ */
+char get_cell() {
+    
+    int i = getchar();
+    
+    if(i == -1)
+        return 0;
+    else
+        return (char)i;
+    
+}
 
 /*
  * Reads code from a line, returns number of unmatched quotes
@@ -232,9 +246,7 @@ void interpret(environment &env) {
                 break;
 
             case '?':
-                CELL cell;
-                std::cin >> cell;
-                (*env.mp) = cell;
+                (*env.mp) = get_cell();
                 env.ip++;
                 break;
 


### PR DESCRIPTION
**Summary:** `?` now can take any character as input, as well as detect EOF.

**Motivation:**
 1. To have a somewhat sane cat program: `?"!?'"`.
 2. To make the input command less frustrating to use in general.

## Previous behaviour

`?` would repeat the last character in the stream if it ran out of characters to consume. Furthermore, it would skip certain characters (such as linefeeds) when processing input. Whether or not this was by design is unclear.

## Implemented behaviour

`?` takes 1 raw character of input using the method `getchar()` inherited from C. When encountering EOF, `?` will set the current cell to `0`.